### PR TITLE
Block lxml binaries to avoid libxml2 incompatibilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+--no-binary lxml
 lxml >= 3.8.0, !=4.7.0


### PR DESCRIPTION
When xmlsec and lxml are linked to different libxml2 versions there can be subtle compatibility issues. Forcing lxml to install from source causes it to link to same system verision of libxml2 as xmlsec.

See https://bugs.launchpad.net/lxml/+bug/1960668 for the sorts of issues this should solve.

This problem occurs because xmlsec is linked to system libxml2 library, but lxml binaries bundle and link to a private copy of libxml2 that may be a different and incompatible version.