### PR TITLE
Don't define `MODULE_NAME` as a string literal

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -13,7 +13,7 @@
 #include "debug.h"
 
 #ifndef MODULE_NAME
-#define MODULE_NAME "xmlsec"
+#define MODULE_NAME xmlsec
 #endif
 
 #define JOIN(X,Y) DO_JOIN1(X,Y)


### PR DESCRIPTION
The `MODULE_NAME` macro is used in contexts where a string literal is not valid, but the fallback value set in `src/common.h` defines it as such; this differs from how it is defined in `setup.py`. Define `MODULE_NAME` in `src/common.h` as it is defined in `setup.py`.

Fixes #267.