### PR TITLE
Exclude softhsm_setup.py from flake8 lints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: 5.0.4
     hooks:
     -   id: flake8
-        exclude: ^setup.py$
+        exclude: ^setup.py|softhsm_setup.py$
         additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-logging-format, flake8-builtins, flake8-eradicate, flake8-fixme, pep8-naming, flake8-pep3101, flake8-annotations-complexity,flake8-pyi]
 -   repo: https://github.com/PyCQA/isort
     rev: 5.12.0


### PR DESCRIPTION
Update `.pre-commit-config.yaml` to exclude `softhsm_setup.py` from the flake8 lints. This gets pre-commit passing for this repo again.