### PR TITLE
Configure options for libxmlsec1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -437,6 +437,7 @@ class build_ext(build_ext_orig):
                 prefix_arg,
                 '--disable-shared',
                 '--disable-gost',
+                '--enable-md5',
                 '--disable-crypto-dl',
                 '--enable-static=yes',
                 '--enable-shared=no',


### PR DESCRIPTION
Set the `enable-md5` option for libxmlsec1 when doing a static build. 

Without this option set we get the following errors when trying to run the tests:
```
xmlSecOpenSSLTransformMd5GetKlass: symbol not found
```