### PR TITLE
Update osx workflow 

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -19,8 +19,9 @@ jobs:
       - name: Build macosx_x86_64 wheel
         env:
           CC: clang
-          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
-          LDFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
+          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -I/usr/local/opt/libxml2/include"
+          LDFLAGS: "-fprofile-instr-generate -fcoverage-mapping -L/usr/local/opt/libxml2/lib"
+          PKG_CONFIG_PATH: "/usr/local/opt/libxml2/lib/pkgconfig"
         run: |
           python -m build
           rm -rf build/
@@ -31,9 +32,13 @@ jobs:
           echo "LLVM_PROFILE_FILE=pyxmlsec.profraw" >> $GITHUB_ENV
       - name: Install test dependencies
         run: |
-          pip install coverage --upgrade -r requirements-test.txt
+          pip install coverage --upgrade -r requirements-test.txt --no-binary lxml
           pip install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
           echo "PYXMLSEC_LIBFILE=$(python -c 'import xmlsec; print(xmlsec.__file__)')" >> $GITHUB_ENV
+        env:
+          CFLAGS: "-I/usr/local/opt/libxml2/include"
+          LDFLAGS: "-L/usr/local/opt/libxml2/lib"
+          PKG_CONFIG_PATH: "/usr/local/opt/libxml2/lib/pkgconfig"
       - name: Run tests
         run: |
           coverage run -m pytest -v --color=yes

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Report coverage to codecov
         run: |
           /Library/Developer/CommandLineTools/usr/bin/llvm-profdata merge -sparse ${{ env.LLVM_PROFILE_FILE }} -output pyxmlsec.profdata
-          /Library/Developer/CommandLineTools/usr/bin/llvm-cov show ${{ env.PYXMLSEC_LIBFILE }} --arch=x86_64 --instr-profile=pyxmlsec.profdata src > coverage.txt
+          /Library/Developer/CommandLineTools/usr/bin/llvm-cov show ${{ env.PYXMLSEC_LIBFILE }} --arch=$(uname -m) --instr-profile=pyxmlsec.profdata src > coverage.txt
           bash <(curl -s https://codecov.io/bash) -f coverage.txt

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -36,6 +36,7 @@ jobs:
           pip install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
           echo "PYXMLSEC_LIBFILE=$(python -c 'import xmlsec; print(xmlsec.__file__)')" >> $GITHUB_ENV
         env:
+          CC: clang
           CFLAGS: "-I/usr/local/opt/libxml2/include"
           LDFLAGS: "-L/usr/local/opt/libxml2/lib"
           PKG_CONFIG_PATH: "/usr/local/opt/libxml2/lib/pkgconfig"
@@ -45,5 +46,5 @@ jobs:
       - name: Report coverage to codecov
         run: |
           /Library/Developer/CommandLineTools/usr/bin/llvm-profdata merge -sparse ${{ env.LLVM_PROFILE_FILE }} -output pyxmlsec.profdata
-          /Library/Developer/CommandLineTools/usr/bin/llvm-cov show ${{ env.PYXMLSEC_LIBFILE }} -instr-profile=pyxmlsec.profdata src > coverage.txt
+          /Library/Developer/CommandLineTools/usr/bin/llvm-cov -arch x86_64 show ${{ env.PYXMLSEC_LIBFILE }} -instr-profile=pyxmlsec.profdata src > coverage.txt
           bash <(curl -s https://codecov.io/bash) -f coverage.txt

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -21,7 +21,7 @@ jobs:
           CC: clang
           CFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
           LDFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
-          PKG_CONFIG_PATH: "/usr/local/opt/libxml2/lib/pkgconfig"
+          PKG_CONFIG_PATH: "$(brew --prefix)/opt/libxml2/lib/pkgconfig"
         run: |
           python -m build
           rm -rf build/

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -21,8 +21,8 @@ jobs:
           CC: clang
           CFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
           LDFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
-          PKG_CONFIG_PATH: "$(brew --prefix)/opt/libxml2/lib/pkgconfig"
         run: |
+          export PKG_CONFIG_PATH="$(brew --prefix)/opt/libxml2/lib/pkgconfig"
           python -m build
           rm -rf build/
       - name: Set environment variables

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Report coverage to codecov
         run: |
           /Library/Developer/CommandLineTools/usr/bin/llvm-profdata merge -sparse ${{ env.LLVM_PROFILE_FILE }} -output pyxmlsec.profdata
-          /Library/Developer/CommandLineTools/usr/bin/llvm-cov -arch x86_64 show ${{ env.PYXMLSEC_LIBFILE }} -instr-profile=pyxmlsec.profdata src > coverage.txt
+          /Library/Developer/CommandLineTools/usr/bin/llvm-cov show ${{ env.PYXMLSEC_LIBFILE }} --arch=x86_64 --instr-profile=pyxmlsec.profdata src > coverage.txt
           bash <(curl -s https://codecov.io/bash) -f coverage.txt

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -32,14 +32,9 @@ jobs:
           echo "LLVM_PROFILE_FILE=pyxmlsec.profraw" >> $GITHUB_ENV
       - name: Install test dependencies
         run: |
-          pip install coverage --upgrade -r requirements-test.txt --no-binary lxml
+          pip install coverage --upgrade -r requirements-test.txt
           pip install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
           echo "PYXMLSEC_LIBFILE=$(python -c 'import xmlsec; print(xmlsec.__file__)')" >> $GITHUB_ENV
-        env:
-          CC: clang
-          CFLAGS: "-I/usr/local/opt/libxml2/include"
-          LDFLAGS: "-L/usr/local/opt/libxml2/lib"
-          PKG_CONFIG_PATH: "/usr/local/opt/libxml2/lib/pkgconfig"
       - name: Run tests
         run: |
           coverage run -m pytest -v --color=yes

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Build macosx_x86_64 wheel
         env:
           CC: clang
-          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -I/usr/local/opt/libxml2/include"
-          LDFLAGS: "-fprofile-instr-generate -fcoverage-mapping -L/usr/local/opt/libxml2/lib"
+          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
+          LDFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
           PKG_CONFIG_PATH: "/usr/local/opt/libxml2/lib/pkgconfig"
         run: |
           python -m build


### PR DESCRIPTION
Update osx workflow to make sure that the brew installed version of `libxml2` is in the path when compiling xmlsec, rather then the osx system supplied one, to avoid the issue noted in https://github.com/xmlsec/python-xmlsec/issues/283 where the tests segfault. This is done by setting `PKG_CONFIG_PATH`.

This gets the workflow for osx in a mostly passing state. Tests pass for Python 3.6 - 3.11. Tests for Python 3.5 are still failing because the type annotations added in https://github.com/xmlsec/python-xmlsec/pull/253 are not valid for Python 3.5. So that either needs to be fixed, or Python 3.5 support needs to get dropped for this to be fully passing.