### PR TITLE
Fix manylinux build workflow

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -7,14 +7,7 @@ jobs:
       matrix:
         python-abi: [cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311]
         image:
-          - manylinux2010_x86_64
-          - manylinux_2_24_x86_64
-          - musllinux_1_1_x86_64
-        exclude:
-          - image: manylinux2010_x86_64
-            python-abi: cp311-cp311
-          - image: manylinux2010_i686
-            python-abi: cp311-cp311
+          - manylinux2014_x86_64
     container: quay.io/pypa/${{ matrix.image }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Now that https://github.com/xmlsec/python-xmlsec/pull/292 has gone in. Update the [manylinux](https://github.com/pypa/manylinux) build workflow to use `manylinux2014_x86_64`, which means we are able to install `lxml` and get the manylinux workflows passing again.

I think we would be better off using `cibuildwheel` instead of this workflow, as in https://github.com/xmlsec/python-xmlsec/pull/294, but I wanted to make a PR to get this one passing anyway since it was a small change.