### PR TITLE
Add CI action for OSX static build

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -6,6 +6,7 @@ jobs:
     strategy:
       matrix:
         python: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        static_deps: ["static", ""]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -21,6 +22,7 @@ jobs:
           CC: clang
           CFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
           LDFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
+          PYXMLSEC_STATIC_DEPS: ${{ matrix.static_deps }}
         run: |
           export PKG_CONFIG_PATH="$(brew --prefix)/opt/libxml2/lib/pkgconfig"
           python -m build
@@ -43,3 +45,4 @@ jobs:
           /Library/Developer/CommandLineTools/usr/bin/llvm-profdata merge -sparse ${{ env.LLVM_PROFILE_FILE }} -output pyxmlsec.profdata
           /Library/Developer/CommandLineTools/usr/bin/llvm-cov show ${{ env.PYXMLSEC_LIBFILE }} --arch=$(uname -m) --instr-profile=pyxmlsec.profdata src > coverage.txt
           bash <(curl -s https://codecov.io/bash) -f coverage.txt
+        if: matrix.static_deps != 'static'

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,11 @@ def make_request(url, github_token=None, json_response=False):
         headers['authorization'] = "Bearer " + github_token
     request = Request(url, headers=headers)
     with contextlib.closing(urlopen(request)) as r:
+        charset = r.headers.get_content_charset() or 'utf-8'
+        content = r.read().decode(charset)
         if json_response:
-            return json.load(r)
+            return json.loads(content)
         else:
-            charset = r.headers.get_content_charset() or 'utf-8'
-            content = r.read().decode(charset)
             return content
 
 


### PR DESCRIPTION
Small update to the mac CI build to build a static wheel, as well as non-static one. https://github.com/xmlsec/python-xmlsec/pull/293 added the ability to do a static build on mac, but didn't exercise it in CI.

This also includes a small change to `setup.py` that I missed. Static builds were failing for Python 3.5 because `json.loads` cannot take a byte string in Python 3.5, so the content has to be decoded first to maintain Python 3.5 compatibility.