### PR TITLE
Remove PYXMLSEC_XMLSEC1_VERSION override

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -3,11 +3,6 @@ on: [push, pull_request]
 jobs:
   manylinux:
     runs-on: ubuntu-latest
-    env:
-      # python-xmlsec is not compatible with xmlsec1 v1.3.3.
-      # So we need to use the rc until the next release.
-      # TODO: Remove it when xmlsec1 v1.3.4 is fully released.
-      PYXMLSEC_XMLSEC1_VERSION: "1.3.4-rc1"
     strategy:
       matrix:
         python-abi: [cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311]


### PR DESCRIPTION
It looks like `xmlsec` 1.3.4 is now fully released, so pinning to the `-rc1` version is breaking the manylinux workflow. This is why that workflow is now failing in #294.