### PR TITLE
Explicitly cast the pointer type in PyXmlSec_ClearReplacedNodes

### DIFF
--- a/src/enc.c
+++ b/src/enc.c
@@ -204,7 +204,7 @@ static void PyXmlSec_ClearReplacedNodes(xmlSecEncCtxPtr ctx, PyXmlSec_LxmlDocume
         PYXMLSEC_DEBUGF("clear replaced node %p", n);
         nn = n->next;
         // if n has references, it will not be deleted
-        elem = PyXmlSec_elementFactory(doc, n);
+        elem = (PyXmlSec_LxmlElementPtr*)PyXmlSec_elementFactory(doc, n);
         if (NULL == elem)
             xmlFreeNode(n);
         else


### PR DESCRIPTION
Fixes https://github.com/xmlsec/python-xmlsec/issues/323