### PR TITLE
Build wheels for Python 3.13

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -99,6 +99,10 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
 
+    env:
+      PYXMLSEC_LIBXML2_VERSION: 2.12.9
+      PYXMLSEC_LIBXSLT_VERSION: 1.1.42
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
         # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==2.16.5
+        run: pipx install cibuildwheel==2.21.3
       - id: set-matrix
         # Once we have the windows build figured out, it can be added here
         # by updating the matrix to include windows builds as well.
@@ -112,7 +112,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.21.3
         with:
           only: ${{ matrix.only }}
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ skip = [
     "cp37-manylinux_aarch64",
     "cp36-musllinux_aarch64",
     "cp37-musllinux_aarch64",
+    "cp36-macosx*",
+    "cp37-macosx*",
+    "cp38-macosx*",
 ]
 test-command = "pytest -v --color=yes {package}/tests"
 before-test = "pip install -r requirements-test.txt"


### PR DESCRIPTION
This PR updates `cibuildwheel` to the latest version (2.21.3), which adds support for building Python 3.13 wheels. This resolves #327. 

It also bumps up the version of libxml2 and libxslt we build wheels with to match the version used by lxml 5.3.0. 

lxml changelog noting the version updates:
https://github.com/lxml/lxml/blob/2c89ba7e115a0d5d4d612e4fb7f6dc8a96bdf2f5/CHANGES.txt#L28