### PR TITLE
Fix sdist CI workflow

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -20,6 +20,7 @@ jobs:
           python setup.py sdist
       - name: Install test dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl opensc softhsm2 libengine-pkcs11-openssl
           pip install --upgrade -r requirements-test.txt --no-binary lxml
           pip install dist/xmlsec-$(python setup.py --version).tar.gz

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -3,12 +3,15 @@ on: [push, pull_request]
 jobs:
   sdist:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python }}
       - name: Install build dependencies
         run: |
           pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
## Fix sdist CI workflow 
- Workflow was missing a `sudo apt-get update` that was causing it to fail.
- Test sdist with Python 3.9 - 3.13

After merging this all the sdist CI workflow should be green.