### PR TITLE
Fix linuxbrew workflow

### DIFF
--- a/.github/workflows/linuxbrew.yml
+++ b/.github/workflows/linuxbrew.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Install brew

--- a/.github/workflows/linuxbrew.yml
+++ b/.github/workflows/linuxbrew.yml
@@ -31,6 +31,6 @@ jobs:
         run: |
           python3 -m venv test_venv
           source test_venv/bin/activate
-          pip3 install --upgrade -r requirements-test.txt
+          pip3 install --upgrade --no-binary=lxml -r requirements-test.txt
           pip3 install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
           pytest -v --color=yes

--- a/.github/workflows/linuxbrew.yml
+++ b/.github/workflows/linuxbrew.yml
@@ -18,19 +18,19 @@ jobs:
           brew update
           brew install python@${{ matrix.python }} gcc libxml2 libxmlsec1 pkg-config
           echo "/home/linuxbrew/.linuxbrew/opt/python@${{ matrix.python }}/libexec/bin" >> $GITHUB_PATH
-      - name: Install python dependencies
+      - name: Build wheel
         run: |
+          python3 -m venv build_venv
+          source build_venv/bin/activate
           pip3 install --upgrade setuptools wheel build
-      - name: Build linux_x86_64 wheel
-        run: |
           export CFLAGS="-I$(brew --prefix)/include"
           export LDFLAGS="-L$(brew --prefix)/lib"
           python3 -m build
           rm -rf build/
-      - name: Install test dependencies
-        run: |
-          pip3 install --upgrade -r requirements-test.txt
-          pip3 install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
       - name: Run tests
         run: |
+          python3 -m venv test_venv
+          source test_venv/bin/activate
+          pip3 install --upgrade -r requirements-test.txt
+          pip3 install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
           pytest -v --color=yes


### PR DESCRIPTION
# Fix linuxbrew workflow
- `linuxbrew.yml` workflow was failing because Python 3.8 is no longer supported
- Remove Python 3.8, and add 3.12 & 3.13
- Brew now requires packages installed with pip to be installed in a venv, so all package installs are now moved to a venv

After this PR is merged all the brew workflows should be green.