### PR TITLE
Fix macosx CI workflow

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -35,7 +35,8 @@ jobs:
           echo "LLVM_PROFILE_FILE=pyxmlsec.profraw" >> $GITHUB_ENV
       - name: Install test dependencies
         run: |
-          pip install coverage --upgrade -r requirements-test.txt
+          export PKG_CONFIG_PATH="$(brew --prefix)/opt/libxml2/lib/pkgconfig"
+          pip install coverage --upgrade --no-binary=lxml -r requirements-test.txt
           pip install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
           echo "PYXMLSEC_LIBFILE=$(python -c 'import xmlsec; print(xmlsec.__file__)')" >> $GITHUB_ENV
       - name: Run tests

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         static_deps: ["static", ""]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The `macosx.yml` workflow is failing because the older Python versions listed there are no longer supported by github actions. Update the workflow to use all currently supported python versions: 3.9 - 3.13.

After this one goes in all the maxosx CI actions should be green again.