### PR TITLE
Enable dynamic versioning via setuptools-scm in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,16 @@
+[project]
+name = "python-xmlsec"
+dynamic = ["version"]
+
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "pkgconfig>=1.5.1", "lxml>=3.8, !=4.7.0"]
+requires = [
+  "setuptools>=42",
+  "wheel",
+  "setuptools_scm[toml]>=3.4",
+  "pkgconfig>=1.5.1",
+  "lxml>=3.8, !=4.7.0"
+]
+build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 files = ['src']


### PR DESCRIPTION
Add [project] section with dynamic versioning support using setuptools-scm as required by setuptools-scm>=7.

- Declares `dynamic = ["version"]` under [project] to comply with PEP 621.
- Ensures version is derived automatically from VCS tags.
- Aligns with modern setuptools configuration practices.