### PR TITLE
Replace urlretrieve with streaming download using urlopen

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build linux_x86_64 wheel
         env:
           PYXMLSEC_STATIC_DEPS: true
-          PYXMLSEC_LIBXML2_VERSION: 2.14.6  # Lock it to libxml2 2.14.6 until the issue with 2.15.x is resolved; e.g. https://github.com/lsh123/xmlsec/issues/948
+          PYXMLSEC_LIBXML2_VERSION: 2.14.6  # Lock it to libxml2 2.14.6 to match it with lxml
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           /opt/python/${{ matrix.python-abi }}/bin/python -m build


### PR DESCRIPTION
Updated setup.py to replace urllib.request.urlretrieve with a streaming download helper based on urlopen. This avoids the drawbacks of urlretrieve, such as lack of streaming support and limited control over requests. Using urlopen allows downloads to be written in chunks, reduces memory usage, and makes it easier to extend the logic with custom headers, retries, or checksum verification in the future. This improves the reliability and security of fetching dependency tarballs during the build process.